### PR TITLE
info_fields option

### DIFF
--- a/lib/omniauth-odnoklassniki/version.rb
+++ b/lib/omniauth-odnoklassniki/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Odnoklassniki
-    VERSION = "0.0.4.1"
+    VERSION = "0.0.4.2"
   end
 end

--- a/lib/omniauth-odnoklassniki/version.rb
+++ b/lib/omniauth-odnoklassniki/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Odnoklassniki
-    VERSION = "0.0.5"
+    VERSION = "0.0.6"
   end
 end

--- a/lib/omniauth-odnoklassniki/version.rb
+++ b/lib/omniauth-odnoklassniki/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Odnoklassniki
-    VERSION = "0.0.4"
+    VERSION = "0.0.5"
   end
 end

--- a/lib/omniauth-odnoklassniki/version.rb
+++ b/lib/omniauth-odnoklassniki/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Odnoklassniki
-    VERSION = "0.0.5"
+    VERSION = "0.0.4.1"
   end
 end

--- a/lib/omniauth-odnoklassniki/version.rb
+++ b/lib/omniauth-odnoklassniki/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Odnoklassniki
-    VERSION = "0.0.4.2"
+    VERSION = "0.0.4"
   end
 end

--- a/lib/omniauth-odnoklassniki/version.rb
+++ b/lib/omniauth-odnoklassniki/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Odnoklassniki
-    VERSION = "0.0.6"
+    VERSION = "0.0.5"
   end
 end

--- a/lib/omniauth/strategies/odnoklassniki.rb
+++ b/lib/omniauth/strategies/odnoklassniki.rb
@@ -68,10 +68,10 @@ module OmniAuth
           }
           params['sig'] = calculate_signature(params)
           params['fields'] = options[:info_fields] if options.key?(:info_fields)
-          Rails.logger.info('ODNOKLASSNIKI REQUEST: #{params.inspect}')
+          Rails.logger.info("ODNOKLASSNIKI REQUEST: #{params.inspect}")
           result = access_token.get('http://api.odnoklassniki.ru/fb.do', :params => params).parsed
           if result['error_code'] || result['error_msg']
-            Rails.logger.info('ODNOKLASSNIKI RESPONSE: #{result.inspect}')
+            Rails.logger.info("ODNOKLASSNIKI RESPONSE: #{result.inspect}")
           end
           raise CallbackError.new(nil, :invalid_response) if result['error_code'] || result['error_msg']
           result

--- a/lib/omniauth/strategies/odnoklassniki.rb
+++ b/lib/omniauth/strategies/odnoklassniki.rb
@@ -66,8 +66,8 @@ module OmniAuth
             'method' => 'users.getCurrentUser',
             'application_key' => options.public_key
           }
-          params['sig'] = calculate_signature(params)
           params['fields'] = options[:info_fields] if options.key?(:info_fields)
+          params['sig'] = calculate_signature(params)
           Rails.logger.info("ODNOKLASSNIKI REQUEST: #{params.inspect}")
           result = access_token.get('http://api.odnoklassniki.ru/fb.do', :params => params).parsed
           if result['error_code'] || result['error_msg']

--- a/lib/omniauth/strategies/odnoklassniki.rb
+++ b/lib/omniauth/strategies/odnoklassniki.rb
@@ -68,7 +68,11 @@ module OmniAuth
           }
           params['sig'] = calculate_signature(params)
           params['fields'] = options[:info_fields] if options.key?(:info_fields)
+          Rails.logger.info('ODNOKLASSNIKI REQUEST: #{params.inspect}')
           result = access_token.get('http://api.odnoklassniki.ru/fb.do', :params => params).parsed
+          if result['error_code'] || result['error_msg']
+            Rails.logger.info('ODNOKLASSNIKI RESPONSE: #{result.inspect}')
+          end
           raise CallbackError.new(nil, :invalid_response) if result['error_code'] || result['error_msg']
           result
         end

--- a/lib/omniauth/strategies/odnoklassniki.rb
+++ b/lib/omniauth/strategies/odnoklassniki.rb
@@ -70,9 +70,7 @@ module OmniAuth
           params['sig'] = calculate_signature(params)
           Rails.logger.info("ODNOKLASSNIKI REQUEST: #{params.inspect}")
           result = access_token.get('http://api.odnoklassniki.ru/fb.do', :params => params).parsed
-          if result['error_code'] || result['error_msg']
-            Rails.logger.info("ODNOKLASSNIKI RESPONSE: #{result.inspect}")
-          end
+          Rails.logger.info("ODNOKLASSNIKI RESPONSE: #{result.inspect}")
           raise CallbackError.new(nil, :invalid_response) if result['error_code'] || result['error_msg']
           result
         end

--- a/lib/omniauth/strategies/odnoklassniki.rb
+++ b/lib/omniauth/strategies/odnoklassniki.rb
@@ -68,9 +68,7 @@ module OmniAuth
           }
           params['fields'] = options[:info_fields] if options.key?(:info_fields)
           params['sig'] = calculate_signature(params)
-          Rails.logger.info("ODNOKLASSNIKI REQUEST: #{params.inspect}")
           result = access_token.get('http://api.odnoklassniki.ru/fb.do', :params => params).parsed
-          Rails.logger.info("ODNOKLASSNIKI RESPONSE: #{result.inspect}")
           raise CallbackError.new(nil, :invalid_response) if result['error_code'] || result['error_msg']
           result
         end

--- a/lib/omniauth/strategies/odnoklassniki.rb
+++ b/lib/omniauth/strategies/odnoklassniki.rb
@@ -67,6 +67,7 @@ module OmniAuth
             'application_key' => options.public_key
           }
           params['sig'] = calculate_signature(params)
+          params['fields'] = options[:info_fields] if options.key?(:info_fields)
           result = access_token.get('http://api.odnoklassniki.ru/fb.do', :params => params).parsed
           raise CallbackError.new(nil, :invalid_response) if result['error_code'] || result['error_msg']
           result


### PR DESCRIPTION
Hi. It would be nice to provide `info_fields` option to allow retrieving some extra info, e-mail for example. I've added the `info_fields` option that will be added to `getCurrentUser` request as `fields` param according to [API docs](https://apiok.ru/wiki/display/api/users.getCurrentUser+ru).

When using with devise I've following example config in `config/intializers/devise.rb`:

```
config.omniauth :odnoklassniki,
                Rails.application.secrets.odnoklassniki_app_id,
                Rails.application.secrets.odnoklassniki_app_secret,
                public_key: Rails.application.secrets.odnoklassniki_app_public,
                scope: 'GET_EMAIL',
                info_fields: %w(UID LOCALE FIRST_NAME LAST_NAME NAME GENDER
                                AGE BIRTHDAY HAS_EMAIL PIC_1 PIC_2 PIC_3
                                LOCATION EMAIL).join(',')

```

Regards!