### PR TITLE
Add email to info if user has email

### DIFF
--- a/lib/omniauth/strategies/odnoklassniki.rb
+++ b/lib/omniauth/strategies/odnoklassniki.rb
@@ -32,7 +32,9 @@ module OmniAuth
           :urls => {
             'Odnoklassniki' => "https://ok.ru/profile/#{uid}",
           }
-        }
+        }.tap do |info|
+          info[:email] = raw_info['email'] if raw_info['email']
+        end
       end
 
       extra do


### PR DESCRIPTION
omniauth-odnoklassniki does not provide the user's email address in the `info`.
I updated the gem so that, if user has an email, and it was provided (this requires the `GET_EMAIL` scope), then it will be in the `info` result.