### PR TITLE
Unlock Omniauth 2.x 

### DIFF
--- a/omniauth-odnoklassniki.gemspec
+++ b/omniauth-odnoklassniki.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "omniauth", "~> 1.0"
+  s.add_runtime_dependency "omniauth", [">= 1.9", "< 3"]
   s.add_runtime_dependency "omniauth-oauth2", "~> 1.0"
 end


### PR DESCRIPTION
Unlock omniauth 2, omniauth-odnoklassniki It's currently locked to use "~> 1.0" this is blocking to move to the new recent [releases](https://github.com/omniauth/omniauth/releases) in omniauth. This similar to what omniauth-oauth2 did on https://github.com/omniauth/omniauth-oauth2/commit/f14f01db7a5391bd13ce4a9d0ab735b4d4f318e1